### PR TITLE
Add IO-Compress-Brotli [CVE-2020-8927]

### DIFF
--- a/cpansa/CPANSA-IO-Compress-Brotli.yml
+++ b/cpansa/CPANSA-IO-Compress-Brotli.yml
@@ -1,0 +1,28 @@
+- affected_versions: "<=0.004001"
+  cves:
+    - CVE-2020-8927
+  description: 'A buffer overflow exists in the Brotli library versions prior to 1.0.8 where an attacker controlling the input length of a "one-shot" decompression request to a script can trigger a crash, which happens when copying over chunks of data larger than 2 GiB. It is recommended to update your Brotli library to 1.0.8 or later. If one cannot update, we recommend to use the "streaming" API as opposed to the "one-shot" API, and impose chunk size limits.'
+  distribution: IO-Compress-Brotli
+  fixed_versions: ~
+  id: CPANSA-IO-Compress-Brotli-2020-8927
+  references:
+    - https://github.com/google/brotli/releases/tag/v1.0.9
+    - http://lists.opensuse.org/opensuse-security-announce/2020-09/msg00108.html
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MMBKACMLSRX7JJSKBTR35UOEP2WFR6QP/
+    - https://usn.ubuntu.com/4568-1/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WW62OZEY2GHJL4JCOLJRBSRETXDHMWRK/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M4VCDOJGL6BK3HB4XRD2WETBPYX2ITF6/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/J4E265WKWKYMK2RYYSIXBEGZTDY5IQE6/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/W23CUADGMVMQQNFKHPHXVP7RPZJZNN6I/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/356JOYTWW4BWSZ42SEFLV7NYHL3S3AEH/
+    - https://lists.debian.org/debian-lts-announce/2020/12/msg00003.html
+    - https://www.debian.org/security/2020/dsa-4801
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZXEQ3GQVELA2T4HNZG7VPMS2HDVXMJRG/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/MQLM7ABVCYJLF6JRPF3M3EBXW63GNC27/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/4TOGTZ2ZWDH662ZNFFSZVL3M5AJXV6JF/
+  reported: 2020-09-15
+  severity: medium
+  reviewed_by:
+    - name: Robert Rothenberg
+      email: rrwo@cpan.org
+      date: 2022-06-15


### PR DESCRIPTION
This issue has been reported to the author.

Note that HTTP-Message 6.37 will make use of IO-Compress-Brotli
if it is installed and the body is uses Brotli ("br") encoding.