### PR TITLE
Clean up the rest of dropbear

### DIFF
--- a/cpansa/CPANSA-Net-Dropbear.yml
+++ b/cpansa/CPANSA-Net-Dropbear.yml
@@ -1,23 +1,5 @@
 ---
-- affected_versions: "<0.11"
-  cves:
-    - CVE-2019-15599
-  description: >
-    A Code Injection exists in tree-kill on Windows which allows a
-    remote code execution when an attacker is able to control the
-    input into the command.
-  distribution: Net-Dropbear
-  embedded_vulnerability:
-    distributed_version: "<=2018.76"
-    name: dropbear
-  fixed_versions: ~
-  id: CPANSA-Net-Dropbear-2019-15599
-  references:
-    - https://metacpan.org/release/ATRODO/Net-Dropbear-0.15/changes
-    - https://hackerone.com/reports/701183
-  reported: 2019-12-18
-  severity: critical
-- affected_versions: ~
+- affected_versions: '<0'
   cves:
     - CVE-2019-17362
   description: >
@@ -38,8 +20,9 @@
   distribution: Net-Dropbear
   embedded_vulnerability:
     distributed_version: "1.8.2"
-    name: libtomcrypt[dropbear]
-  fixed_versions: ~
+    name: libtomcrypt
+    affected_versions: '<0'
+  fixed_versions: '>0'
   id: CPANSA-Net-Dropbear-2019-17362
   references:
     - https://github.com/atrodo/Net-Dropbear/issues/6

--- a/external_reports/dropbear.yml
+++ b/external_reports/dropbear.yml
@@ -38,15 +38,21 @@ advisories:
       - https://matt.ucc.asn.au/dropbear/CHANGES
     reported: 2020-12-30
     severity: medium
-  - cve: CVE-2019-15599
+  - cve: CVE-2018-15599
     description: >
-      A Code Injection exists in tree-kill on Windows which allows a
-      remote code execution when an attacker is able to control the
-      input into the command.
+      The recv_msg_userauth_request function in svr-auth.c in Dropbear
+      through 2018.76 is prone to a user enumeration vulnerability
+      because username validity affects how fields in SSH_MSG_USERAUTH
+      messages are handled, a similar issue to CVE-2018-15473 in an
+      unrelated codebase.
     affected_versions: "<=2018.76"
-    fixed_versions: ~
+    fixed_versions: '>2018.76'
     references:
       - https://metacpan.org/release/ATRODO/Net-Dropbear-0.15/changes
-      - https://hackerone.com/reports/701183
-    reported: 2019-12-18
+      - http://lists.ucc.gu.uwa.edu.au/pipermail/dropbear/2018q3/002108.html
+      - http://lists.ucc.gu.uwa.edu.au/pipermail/dropbear/2018q3/002109.html
+      - https://lists.debian.org/debian-lts-announce/2018/08/msg00026.html
+      - https://matt.ucc.asn.au/dropbear/CHANGES
+      - https://old.reddit.com/r/blackhat/comments/97ywnm/openssh_username_enumeration/e4e05n2/
+    reported: 2018-08-20
     severity: critical

--- a/external_reports/dropbear.yml
+++ b/external_reports/dropbear.yml
@@ -38,3 +38,15 @@ advisories:
       - https://matt.ucc.asn.au/dropbear/CHANGES
     reported: 2020-12-30
     severity: medium
+  - cve: CVE-2019-15599
+    description: >
+      A Code Injection exists in tree-kill on Windows which allows a
+      remote code execution when an attacker is able to control the
+      input into the command.
+    affected_versions: "<=2018.76"
+    fixed_versions: ~
+    references:
+      - https://metacpan.org/release/ATRODO/Net-Dropbear-0.15/changes
+      - https://hackerone.com/reports/701183
+    reported: 2019-12-18
+    severity: critical


### PR DESCRIPTION
There's one report that is not really a report. As such, I set affected_versions to '<0' so this should never match. This still means we are aware of the report.