### PR TITLE
Remove embedded bit for Apache-ASP since it doesn't have it

### DIFF
--- a/cpansa/CPANSA-Apache-ASP.yml
+++ b/cpansa/CPANSA-Apache-ASP.yml
@@ -5,9 +5,6 @@
     A bug would allow a malicious user possible writing of files in
     the same directory as the source.asp script.
   distribution: Apache-ASP
-  embedded_vulnerability:
-    distributed_version: ~
-    name: ~
   fixed_versions: '>=1.95'
   id: CPANSA-Apache-ASP-2000-01
   references:

--- a/util/make_record
+++ b/util/make_record
@@ -183,6 +183,10 @@ sub run ( @args ) {
 	$hash->{embedded_vulnerability}{distributed_version} //= $config->embedded_version;
 	$hash->{embedded_vulnerability}{name}                //= $config->embedded_name;
 
+	delete $hash->{embedded_vulnerability} unless(
+		defined $config->embedded_version or defined $config->embedded_name
+		);
+
 	my $string = YAML::Dump( [ $hash ] );
 
 	# We want the folded form to avoid yamllint warnings, but YAML


### PR DESCRIPTION
And, have make_report omit that section if it doesn't need it.

Might change my mind later.