### PR TITLE
sperl was a part of the perl distribution

### DIFF
--- a/cpansa/CPANSA-sperl.yml
+++ b/cpansa/CPANSA-sperl.yml
@@ -1,5 +1,5 @@
 ---
-- affected_versions: ~
+- affected_versions: ">=4.0,<5.4.0"
   cves:
     - CVE-1999-0034
   description: >
@@ -7,10 +7,12 @@
   distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-1999-0034
-  references: []
+  references:
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/448
+    - https://www.cpan.org/src/5.0/CA-97.17.sperl
   reported: 1997-05-29
   severity: ~
-- affected_versions: ~
+- affected_versions: ">=4.0,<5.6.0"
   cves:
     - CVE-1999-0462
   description: >
@@ -25,7 +27,7 @@
     - http://www.securityfocus.com/bid/339
   reported: 1999-03-17
   severity: ~
-- affected_versions: ~
+- affected_versions: '<5.6.1'
   cves:
     - CVE-2000-0703
   description: >
@@ -47,5 +49,6 @@
     - http://archives.neohapsis.com/archives/bugtraq/2000-08/0153.html
     - http://archives.neohapsis.com/archives/bugtraq/2000-08/0086.html
     - http://archives.neohapsis.com/archives/bugtraq/2000-08/0113.html
+    - https://www.cpan.org/src/5.0/sperl-2000-08-05/sperl-2000-08-05.txt
   reported: 2000-10-20
   severity: ~

--- a/cpansa/CPANSA-sperl.yml
+++ b/cpansa/CPANSA-sperl.yml
@@ -4,7 +4,7 @@
     - CVE-1999-0034
   description: >
     Buffer overflow in suidperl (sperl), Perl 4.x and 5.x.
-  distribution: 'sperl'
+  distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-1999-0034
   references: []
@@ -18,7 +18,7 @@
     file systems, allowing local users to gain root access by placing
     a setuid script in a mountable file system, e.g. a CD-ROM or
     floppy disk.
-  distribution: 'sperl'
+  distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-1999-0462
   references:
@@ -34,7 +34,7 @@
     allows local users to gain privileges by setting the "interactive"
     environmental variable and calling suidperl with a filename that
     contains the escape sequence.
-  distribution: 'sperl'
+  distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-2000-0703
   references:


### PR DESCRIPTION
Hey brian! This is another issue we spotted. "suidperl", during its existance, was bundled with the perl distribution.

We have not changed the CPANSA id (nor the filename for that matter) since we believe those should remain static.

Thanks!