### PR TITLE
normalize version ranges

### DIFF
--- a/cpansa/CPANSA-ActivePerl.yml
+++ b/cpansa/CPANSA-ActivePerl.yml
@@ -1,5 +1,5 @@
 ---
-- affected_versions: "5.16.1.1601"
+- affected_versions: "=5.16.1.1601"
   cves:
     - CVE-2012-5377
   description: >
@@ -19,7 +19,7 @@
     - http://osvdb.org/86177
   reported: 2012-10-11
   severity: ~
-- affected_versions: "5.8.8.817"
+- affected_versions: "=5.8.8.817"
   cves:
     - CVE-2006-2856
   description: >

--- a/cpansa/CPANSA-DBD-SQLite.yml
+++ b/cpansa/CPANSA-DBD-SQLite.yml
@@ -262,7 +262,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2020-02-21
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-20218
   description: >
@@ -280,7 +280,7 @@
     - https://lists.debian.org/debian-lts-announce/2020/12/msg00016.html
   reported: 2020-01-02
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19959
   description: >
@@ -298,7 +298,7 @@
     - https://www.oracle.com/security-alerts/cpuapr2020.html
   reported: 2020-01-03
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19926
     - CVE-2019-19880
@@ -373,7 +373,7 @@
     - https://usn.ubuntu.com/4205-1/
   reported: 2019-05-10
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19925
   description: >
@@ -395,7 +395,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-12-24
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19924
   description: >
@@ -415,7 +415,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-12-24
   severity: medium
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19923
   description: >
@@ -438,7 +438,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-12-24
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19880
   description: >
@@ -499,7 +499,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-12-09
   severity: medium
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19603
   description: >
@@ -518,7 +518,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-12-09
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19317
   description: >
@@ -536,7 +536,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-12-05
   severity: critical
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19244
   description: >
@@ -553,7 +553,7 @@
     - https://cert-portal.siemens.com/productcert/pdf/ssa-389290.pdf
   reported: 2019-11-25
   severity: high
-- affected_versions: "1.65_02"
+- affected_versions: "=1.65_02"
   cves:
     - CVE-2019-19242
   description: >
@@ -612,7 +612,7 @@
     - https://kc.mcafee.com/corporate/index?page=content&id=SB10365
   reported: 2019-04-03
   severity: high
-- affected_versions: "1.59_02"
+- affected_versions: "=1.59_02"
   cves:
     - CVE-2018-20505
   description: >
@@ -723,7 +723,9 @@
     - https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E
   reported: 2018-03-17
   severity: high
-- affected_versions: "1.55_06,<=1.55_03"
+- affected_versions:
+    - "=1.55_06"
+    - "<=1.55_03"
   cves:
     - CVE-2017-10989
   description: >
@@ -873,7 +875,7 @@
     - http://www.oracle.com/technetwork/security-advisory/cpujul2018-4258247.html
   reported: 2015-04-24
   severity: ~
-- affected_versions: "1.47_01"
+- affected_versions: "=1.47_01"
   cves:
     - CVE-2013-7443
   description: >

--- a/cpansa/CPANSA-Dpkg.yml
+++ b/cpansa/CPANSA-Dpkg.yml
@@ -319,7 +319,7 @@
     - https://exchange.xforce.ibmcloud.com/vulnerabilities/56887
   reported: 2010-03-15
   severity: ~
-- affected_versions: '1.9.21'
+- affected_versions: '=1.9.21'
   cves:
     - CVE-2004-2768
   description: >

--- a/cpansa/CPANSA-IPC-Run.yml
+++ b/cpansa/CPANSA-IPC-Run.yml
@@ -9,5 +9,8 @@
     - https://metacpan.org/dist/IPC-Run/changes
     - https://rt.cpan.org/Public/Bug/Display.html?id=49693
   cves: []
-  affected_versions: "<0.90,0.90_01,0.90_02"
+  affected_versions:
+    - "<0.90"
+    - "=0.90_01"
+    - "=0.90_02"
   fixed_versions: ">=0.90"

--- a/cpansa/CPANSA-sperl.yml
+++ b/cpansa/CPANSA-sperl.yml
@@ -1,5 +1,5 @@
 ---
-- affected_versions: ~
+- affected_versions: ">=4.0,<5.4.0"
   cves:
     - CVE-1999-0034
   description: >
@@ -7,10 +7,12 @@
   distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-1999-0034
-  references: []
+  references:
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/448
+    - https://www.cpan.org/src/5.0/CA-97.17.sperl
   reported: 1997-05-29
   severity: ~
-- affected_versions: ~
+- affected_versions: ">=4.0,<5.6.0"
   cves:
     - CVE-1999-0462
   description: >
@@ -25,7 +27,7 @@
     - http://www.securityfocus.com/bid/339
   reported: 1999-03-17
   severity: ~
-- affected_versions: ~
+- affected_versions: '<5.6.1'
   cves:
     - CVE-2000-0703
   description: >
@@ -47,5 +49,6 @@
     - http://archives.neohapsis.com/archives/bugtraq/2000-08/0153.html
     - http://archives.neohapsis.com/archives/bugtraq/2000-08/0086.html
     - http://archives.neohapsis.com/archives/bugtraq/2000-08/0113.html
+    - https://www.cpan.org/src/5.0/sperl-2000-08-05/sperl-2000-08-05.txt
   reported: 2000-10-20
   severity: ~

--- a/cpansa/CPANSA-sperl.yml
+++ b/cpansa/CPANSA-sperl.yml
@@ -4,7 +4,7 @@
     - CVE-1999-0034
   description: >
     Buffer overflow in suidperl (sperl), Perl 4.x and 5.x.
-  distribution: 'sperl'
+  distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-1999-0034
   references: []
@@ -18,7 +18,7 @@
     file systems, allowing local users to gain root access by placing
     a setuid script in a mountable file system, e.g. a CD-ROM or
     floppy disk.
-  distribution: 'sperl'
+  distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-1999-0462
   references:
@@ -34,7 +34,7 @@
     allows local users to gain privileges by setting the "interactive"
     environmental variable and calling suidperl with a filename that
     contains the escape sequence.
-  distribution: 'sperl'
+  distribution: 'perl'
   fixed_versions: ~
   id: CPANSA-sperl-2000-0703
   references:


### PR DESCRIPTION
For consistency, we made all version definitions include the '=' sign when it's a direct match. This makes it easier to parse and to spot errors (in case the submitter simply forgot to add a sign and the match was not really '='.