### PR TITLE
fix "affected versions" for CVE-2022-48522

### DIFF
--- a/cpansa/CPANSA-perl.yml
+++ b/cpansa/CPANSA-perl.yml
@@ -1007,6 +1007,9 @@
   id: CPANSA-perl-2022-48522
   references:
     - https://github.com/Perl/perl5/blob/79a7b254d85a10b65126ad99bf10e70480569d68/sv.c#L16336-L16345
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-48522
+    - https://security.netapp.com/advisory/ntap-20230915-0008/
+    - https://ubuntu.com/security/CVE-2022-48522
   reported: 2023-08-22
   severity: ~
 - affected_versions: '>=5.30.0,<5.34.3,>=5.36.0,<5.36.3,>=5.38.0,<5.38.2'

--- a/cpansa/CPANSA-perl.yml
+++ b/cpansa/CPANSA-perl.yml
@@ -995,7 +995,7 @@
     - https://www.oracle.com/security-alerts/cpujul2020.html
   reported: 2017-09-28
   severity: critical
-- affected_versions: '>=5.34.0'
+- affected_versions: '=5.34.0'
   cves:
     - CVE-2022-48522
   description: >
@@ -1003,7 +1003,7 @@
     stack-based crash that can lead to remote code execution or local
     privilege escalation.
   distribution: perl
-  fixed_versions: ~
+  fixed_versions: '>=5.34.1'
   id: CPANSA-perl-2022-48522
   references:
     - https://github.com/Perl/perl5/blob/79a7b254d85a10b65126ad99bf10e70480569d68/sv.c#L16336-L16345


### PR DESCRIPTION
This issue only affects perl 5.34.0. It was fixed in 5.35.5 and 5.34.1.

Sources:
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-48522
- https://security.netapp.com/advisory/ntap-20230915-0008/
- https://ubuntu.com/security/CVE-2022-48522
- https://github.com/Perl/perl5/issues/19147