### PR TITLE
cpansa/CPANSA-Mojolicious.yml: fix format issue

### DIFF
--- a/cpansa/CPANSA-Mojolicious.yml
+++ b/cpansa/CPANSA-Mojolicious.yml
@@ -95,7 +95,8 @@
     - https://github.com/mojolicious/mojo/pull/1217
     - https://github.com/mojolicious/mojo/commit/23ebe051d9378f0f122e3c908845fc0c2cae0106
 - id: CPANSA-Mojolicious-2018-01
-  cves: [CVE-2018-25100]
+  cves:
+    - CVE-2018-25100
   distribution: Mojolicious
   reported: 2018-02-13
   severity: minor


### PR DESCRIPTION
My apologies, I believe I screwed up on the insertion of this CVE.  

```
cpan-audit modules "Mojolicious"
Can't use string ("[CVE-2018-25100]") as an ARRAY ref while "strict refs" in use at /home/tim/perl5/perlbrew/perls/perl-5.38.0/bin/cpan-audit line 48.

```