### PR TITLE
Update affected versions for CPANSA-HTTP-Body-2013-4407

### DIFF
--- a/cpansa/CPANSA-HTTP-Body.yml
+++ b/cpansa/CPANSA-HTTP-Body.yml
@@ -4,7 +4,7 @@
   reported: 2013-09-02
   severity: moderate
   description: >
-    HTTP::Body::Multipart in the HTTP-Body 1.08, 1.17, and earlier
+    HTTP::Body::Multipart in the HTTP-Body 1.08, 1.22, and earlier
     module for Perl uses the part of the uploaded file's name after
     the first "." character as the suffix of a temporary file, which
     makes it easier for remote attackers to conduct attacks by
@@ -13,7 +13,7 @@
   references:
     - https://security-tracker.debian.org/tracker/CVE-2013-4407
     - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=721634
-  affected_versions: ">=1.08,<1.19"
+  affected_versions: ">=1.08,<1.23"
   cves:
     - CVE-2013-4407
   fixed_versions: ~


### PR DESCRIPTION
HTTP-Body 1.23 fixes this vulnerability. It was not fixed in 1.18 as indicated by the CVE description, a request to update this has been sent to MITRE.

- https://metacpan.org/pod/HTTP::Body
- http://git.shadowcat.co.uk/gitweb/gitweb.cgi?p=catagits/HTTP-Body.git;a=commitdiff;h=13ac5b23c083bc56e32dd706ca02fca292bd2161
- http://git.shadowcat.co.uk/gitweb/gitweb.cgi?p=catagits/HTTP-Body.git;a=commitdiff;h=cc75c886256f187cda388641931e8dafad6c2346