### PR TITLE
Add metadata to libtommath for CryptX

### DIFF
--- a/external_reports/libtommath.yml
+++ b/external_reports/libtommath.yml
@@ -29,3 +29,11 @@ advisories:
     - distributed_library_version: '0.40'
       perl_module_versions: '>=0.01,<0.11'
     name: Net-Dropbear
+  - affected:
+    - distributed_library_version: '1.1.0'
+      perl_module_versions: '>=0.064'
+    - distributed_library_version: '1.0.1'
+      perl_module_versions: '>=0.061,<0.064'
+    - distributed_library_version: '0.42.0'
+      perl_module_versions: '>=0.002,<0.061'
+    name: CryptX


### PR DESCRIPTION
Note that these versions are approximate, because the documentation does not often indicate what commit or even what date the library has been updated to.

libtommath and libtopcrypt also have a long commit history in the development branch before versions were issued, according to the changelog in their repo (which was omitted from CryptX, making it much harder to determine dependencies).