### PR TITLE
perl 5.38.5 and 5.40.3 fix CVE-2025-40909

### DIFF
--- a/cpansa/CPANSA-perl.yml
+++ b/cpansa/CPANSA-perl.yml
@@ -1118,8 +1118,8 @@ advisories:
     description: 'Perl threads have a working directory race condition where file operations may target unintended paths.  If a directory handle is open at thread creation, the process-wide current working directory is temporarily changed in order to clone that handle for the new thread, which is visible from any third (or more) thread already running.   This may lead to unintended operations such as loading code or accessing files from unexpected locations, which a local attacker may be able to exploit.  The bug was introduced in commit 11a11ecf4bea72b17d250cfb43c897be1341861e and released in Perl version 5.13.6'
     fixed_versions:
       - '>=5.41.13'
-      - '5.38.5'
-      - '5.40.3'
+      - '>=5.38.5,<5.40.0'
+      - '>=5.40.3'
     github_security_advisory:
       - GHSA-jpf5-526x-c5hw
     id: CPANSA-perl-2025-40909

--- a/cpansa/CPANSA-perl.yml
+++ b/cpansa/CPANSA-perl.yml
@@ -1110,12 +1110,16 @@ advisories:
     reported: 2025-04-13
     severity: ~
   - affected_versions:
-      - '>=5.16.3,<5.41.13'
+      - '>=5.16.3,<5.38.5'
+      - '>=5.40.0,<5.40.3'
+      - '>=5.41.0,<5.41.13'
     cves:
       - CVE-2025-40909
     description: 'Perl threads have a working directory race condition where file operations may target unintended paths.  If a directory handle is open at thread creation, the process-wide current working directory is temporarily changed in order to clone that handle for the new thread, which is visible from any third (or more) thread already running.   This may lead to unintended operations such as loading code or accessing files from unexpected locations, which a local attacker may be able to exploit.  The bug was introduced in commit 11a11ecf4bea72b17d250cfb43c897be1341861e and released in Perl version 5.13.6'
     fixed_versions:
       - '>=5.41.13'
+      - '5.38.5'
+      - '5.40.3'
     github_security_advisory:
       - GHSA-jpf5-526x-c5hw
     id: CPANSA-perl-2025-40909


### PR DESCRIPTION
https://perldoc.perl.org/5.38.5/perldelta
https://perldoc.perl.org/5.40.3/perldelta