### PR TITLE
Fix affected_versions with improperly split rules

### DIFF
--- a/cpansa/CPANSA-Encode.yml
+++ b/cpansa/CPANSA-Encode.yml
@@ -17,8 +17,7 @@ advisories:
   reported: 2016-07-27
   severity: high
 - affected_versions:
-  - '>=3.05'
-  - <=3.11
+  - '>=3.05,<=3.11'
   cves:
   - CVE-2021-36770
   description: |

--- a/cpansa/CPANSA-IO-Socket-SSL.yml
+++ b/cpansa/CPANSA-IO-Socket-SSL.yml
@@ -26,8 +26,7 @@ advisories:
   reported: 2011-01-14
   severity: ~
 - affected_versions:
-  - '>=1.14'
-  - <=1.25
+  - '>=1.14,<=1.25'
   cves:
   - CVE-2009-3024
   description: |


### PR DESCRIPTION
Fix the data for CPANSA-Encode-2021-01 and CPANSA-IO-Socket-SSL-2009-3024 which had their affected_versions improperly split into separate rules.