### PR TITLE
CVE-2022-4993 for HTML-FormHandler is fixed in 0.410000

### DIFF
--- a/cpansa/CPANSA-HTML-FormHandler.yml
+++ b/cpansa/CPANSA-HTML-FormHandler.yml
@@ -1,7 +1,7 @@
 ---
 advisories:
 - affected_versions:
-  - '>0'
+  - <0.410000
   cves:
   - CVE-2022-4993
   description: |-
@@ -12,12 +12,15 @@ advisories:
     Three kinds of text the library did not author reach that position. _apply_actions installs a `$SIG{__WARN__}` handler that stores the warning text in `$error_message`, and a captured warning survives a successful action, so a field carrying a numeric transform turns `Argument "[sprintf,%50000000d,0]" isn't numeric` into the template; a warning quotes the submitted value verbatim, so the group is well formed and dispatches. `$error_message ||= $tobj->validate($new_value)` takes a type constraint's own failure message, which renders the rejected value through a partial dumper in bracket and comma form (Devel::PartialDump when Moose can load it, Type::Tiny's own dumper always), so a field with `apply => [ Str ]` given a parameter sent more than once, which arrives as an array, gets `Reference ["a","b"] did not pass type constraint "Str"` as its template, from a request that carries no bracket character of its own. A coercion or transform exception reaches it the same way. Beyond those, a validator whose message contains the field value puts that value in the template directly, and add_error replaces the message list with the contents of an arrayref first argument (`@message = @{$message[0]} if ref $message[0] eq 'ARRAY'`), so a value arriving as an array fills the argument slots from the same request as well.
 
     A malformed group such as `[0]` makes the compile croak, and HTML::FormHandler::I18N::maketext and add_error each re-raise that as a die, so process() throws. A well formed group naming sprintf reaches CORE::sprintf with an attacker chosen field width. Any caller that applies a type constraint or a transform to an untrusted field, or whose validator passes an untrusted field value to add_error, can be made to throw an unhandled exception out of process(), or to allocate an arbitrary amount of memory in one request, and an application whose language handle subclass defines side effecting public methods makes those callable with attacker chosen arguments. The dumped type constraint message is bounded to the exception, because both dumpers quote non-numeric elements so the method slot is never an attacker chosen name. The built-in messages pass fixed templates with the value in an argument slot, where it stays inert, and the built-in field types attach explicit message callbacks, so neither is affected.
-  fixed_versions: []
+  fixed_versions:
+  - '>=0.410000'
   github_security_advisory:
   - GHSA-7p5w-9cxg-wcf3
   id: CPANSA-HTML-FormHandler-2022-4993
   references:
+  - https://github.com/gshank/html-formhandler/commit/fb1439a142d0557e2c5c726688c2788eea07145d
   - https://github.com/gshank/html-formhandler/pull/159
+  - https://metacpan.org/release/ABRAXXA/HTML-FormHandler-0.410000/changes
   - https://metacpan.org/release/GSHANK/HTML-FormHandler-0.40068/source/lib/HTML/FormHandler/Field.pm#L861-876
   - https://metacpan.org/release/GSHANK/HTML-FormHandler-0.40068/source/lib/HTML/FormHandler/I18N/en_us.pm#L9-11
   - https://metacpan.org/release/GSHANK/HTML-FormHandler-0.40068/source/lib/HTML/FormHandler/Validate.pm#L161-261
@@ -28,6 +31,6 @@ advisories:
 cpansa_version: 2
 darkpan: ~
 distribution: HTML-FormHandler
-last_checked: 1786808851
-latest_version: '0.40068'
+last_checked: 1789065739
+latest_version: '0.410002'
 metacpan: https://metacpan.org/pod/HTML::FormHandler


### PR DESCRIPTION
The record for CPANSA-HTML-FormHandler-2022-4993 has `affected_versions: '>0'` and
no `fixed_versions`. There's a fix now: HTML::FormHandler has a new maintainer
(ABRAXXA), and 0.410000 merged gshank/html-formhandler#159 (commit fb1439a), which
passes error messages built from request data as Locale::Maketext arguments rather
than as templates.

The fix landed in 0.410000 although the Changes entry was not added until 0.410001.
So:

* `affected_versions` is now `<0.410000`
* `fixed_versions` is `>=0.410000`